### PR TITLE
refactor: remove public access modifier 

### DIFF
--- a/infra/api/apiClient/ApiClient.ts
+++ b/infra/api/apiClient/ApiClient.ts
@@ -6,32 +6,32 @@ export class ApiClient {
         this.request = request;
     }
 
-    public async get<T>(url: string, options: ApiOptionalParams<T> = {}) {
+    async get<T>(url: string, options: ApiOptionalParams<T> = {}) {
         let response = await this.makeRequest(RequestMethod.GET, url, options)
         return response;
     }
 
-    public async post<T>(url: string, options: ApiOptionalParams<T> = {}) {
+    async post<T>(url: string, options: ApiOptionalParams<T> = {}) {
         let response = await this.makeRequest(RequestMethod.POST, url, options)
         return response;
     }
 
-    public async put<T>(url: string, options: ApiOptionalParams<T> = {}) {
+    async put<T>(url: string, options: ApiOptionalParams<T> = {}) {
         let response = await this.makeRequest(RequestMethod.PUT, url, options)
         return response;
     }
 
-    public async patch<T>(url: string, options: ApiOptionalParams<T> = {}) {
+    async patch<T>(url: string, options: ApiOptionalParams<T> = {}) {
         let response = await this.makeRequest(RequestMethod.PATCH, url, options)
         return response;
     }
 
-    public async delete<T>(url: string, options: ApiOptionalParams<T> = {}) {
+    async delete<T>(url: string, options: ApiOptionalParams<T> = {}) {
         let response = await this.makeRequest(RequestMethod.DELETE, url, options)
         return response;
     }
 
-    public async paginateRequest<T>(
+    async paginateRequest<T>(
         method: RequestMethod,
         url: string,
         paginationType: PaginationType,


### PR DESCRIPTION
 remove public access modifier from API client methods for consistency